### PR TITLE
Fix division by zero

### DIFF
--- a/CsrfTokenManager.php
+++ b/CsrfTokenManager.php
@@ -136,6 +136,10 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
         $key = base64_decode(strtr($parts[1], '-_', '+/'));
         $value = base64_decode(strtr($parts[2], '-_', '+/'));
 
+        if (!$key || !$value) {
+            return '';
+        }
+
         return $this->xor($value, $key);
     }
 

--- a/Tests/CsrfTokenManagerTest.php
+++ b/Tests/CsrfTokenManagerTest.php
@@ -193,6 +193,26 @@ class CsrfTokenManagerTest extends TestCase
         $this->assertFalse($manager->isTokenValid(new CsrfToken('token_id', 'FOOBAR')));
     }
 
+    public function testTokenShouldNotTriggerDivisionByZero()
+    {
+        [$generator, $storage] = $this->getGeneratorAndStorage();
+        $manager = new CsrfTokenManager($generator, $storage);
+
+        // Scenario: the token that was returned is abc.def.ghi, and gets modified in the browser to abc..ghi
+
+        $storage->expects($this->once())
+            ->method('hasToken')
+            ->with('https-token_id')
+            ->willReturn(true);
+
+        $storage->expects($this->once())
+            ->method('getToken')
+            ->with('https-token_id')
+            ->willReturn('def');
+
+        $this->assertFalse($manager->isTokenValid(new CsrfToken('token_id', 'abc..ghi')));
+    }
+
     /**
      * @dataProvider getManagerGeneratorAndStorage
      */


### PR DESCRIPTION
Given: CSRF token abc.def.ghi was returned
When: I change the value of this token in my browser to abc..ghi
Then: the key becomes '' and the xor that is called in denormalize results in a division by zero and http 500